### PR TITLE
dX2dx in Scheimpflug model

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -1,4 +1,6 @@
 # demo of par2vel
+import os
+os.system('cd ..')
 import numpy as np
 import matplotlib.pyplot as plt
 from par2vel.camera import One2One

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -1,6 +1,4 @@
 # demo of par2vel
-import os
-os.system('cd ..')
 import numpy as np
 import matplotlib.pyplot as plt
 from par2vel.camera import One2One

--- a/par2vel/camera.py
+++ b/par2vel/camera.py
@@ -488,7 +488,14 @@ class Scheimpflug(Camera):
         X2 = zeros((1,nj))
         X = vstack((X0, X1, X2))
         return X
-
+    def dX2dx(self, X, dX):
+        """Use camera models to transform displacement in object coordinates
+        to displacement in image coordinates"""
+        x = self.X2x(X)
+        x2 = self.X2x(numpy.add(X,dX))
+        dx = x2-x
+        
+        return dx
                 
 def readimage(filename):
     """ Read grayscale image from file """

--- a/par2vel/camera.py
+++ b/par2vel/camera.py
@@ -395,7 +395,20 @@ class Scheimpflug(Camera):
                 self.set_keyword(line)
             n += 1
         self.shape = self.pixels
-        
+      
+    def dx2dX(self, x, dx, z=0):
+        """Transform displacement in pixel to physical displacement.
+           The displacement is assumed to be at the z=0 plane in
+           physical space.
+        """
+        # very simple model setting physical coordinates to image coord.
+        from numpy import zeros, vstack
+        X = self.x2X(x)
+        X2 = self.x2X(x+dx)
+        dX = X2-X
+        # dummy, n = dx.shape
+        # dX = vstack((dx, zeros((1,n))))
+        return dX      
 
     def save_camera(self, filename):
         """Save camera definition and/or calibration data"""


### PR DESCRIPTION
Created dX2dx for the Scheimpflug camera model. The function didn't exist, but will be necessary to perform stereo PIV. It is build the same way as the dx2dX function for the Scheimpflug model, so it would maybe be necessary to change it a little bit later on in order to improve efficiency.