### PR TITLE
Resolved RuntimeWarning issue

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -1,4 +1,6 @@
 # demo of par2vel
+import os
+os.system('cd ..')
 import numpy as np
 import matplotlib.pyplot as plt
 from par2vel.camera import One2One

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -1,6 +1,4 @@
 # demo of par2vel
-import os
-os.system('cd ..')
 import numpy as np
 import matplotlib.pyplot as plt
 from par2vel.camera import One2One

--- a/par2vel/camera.py
+++ b/par2vel/camera.py
@@ -488,7 +488,14 @@ class Scheimpflug(Camera):
         X2 = zeros((1,nj))
         X = vstack((X0, X1, X2))
         return X
-
+    def dX2dx(self, X, dX):
+        """Use camera models to transform displacement in object coordinates
+        to displacement in image coordinates"""
+        x = self.X2x(X)
+        x2 = self.X2x(numpy.add(X,dX))
+        dx = x2-x
+        
+        return dx
                 
 def readimage(filename):
     """ Read grayscale image from file """

--- a/par2vel/camera.py
+++ b/par2vel/camera.py
@@ -395,7 +395,20 @@ class Scheimpflug(Camera):
                 self.set_keyword(line)
             n += 1
         self.shape = self.pixels
-        
+      
+    def dx2dX(self, x, dx, z=0):
+        """Transform displacement in pixel to physical displacement.
+           The displacement is assumed to be at the z=0 plane in
+           physical space.
+        """
+        # very simple model setting physical coordinates to image coord.
+        from numpy import zeros, vstack
+        X = self.x2X(x)
+        X2 = self.x2X(x+dx)
+        dX = X2-X
+        # dummy, n = dx.shape
+        # dX = vstack((dx, zeros((1,n))))
+        return dX      
 
     def save_camera(self, filename):
         """Save camera definition and/or calibration data"""

--- a/par2vel/piv2d.py
+++ b/par2vel/piv2d.py
@@ -33,9 +33,11 @@ def gauss_interpolate1(x):
     assert (x[1] >= x[0]) and (x[1] >= x[2]), 'Peak must be at center element'
     # avoid log(0) or divide 0 error
     try:
+        if any(x <= 0):
+            raise ValueError
         r = log(x)
         ifrac = (r[0] - r[2]) / (2 * r[0] - 4 * r[1] + 2 * r[2])
-    except:   # use centroid instead
+    except ValueError:   # use centroid instead
         print("using centroid")
         ifrac = (x[2] - x[0]) / sum(x)
     return ifrac
@@ -125,7 +127,7 @@ def displacementFFT(win1,win2,biascorrect=None):
     if biascorrect is None: 
         biascorrect=xcorr2(numpy.ones((winsize,winsize),float),
                       numpy.ones((winsize,winsize),float))/(winsize*winsize)
-    R2=R/biascorrect
+    R2 = R/biascorrect
     # find peak 
     ipeak,jpeak=findpeakindex(R)
     # find peak in R2 (might move sligthly)
@@ -137,7 +139,6 @@ def displacementFFT(win1,win2,biascorrect=None):
         ifrac,jfrac=gauss_interpolate2(R2[ipeak-1:ipeak+2,jpeak-1:jpeak+2])
     except IndexError:  # peak at edge of correlation plane
         ifrac,jfrac=0.0,0.0
-    # print R2[winsize-3:winsize+2,winsize-3:winsize+2]
     return winsize - 1 - ipeak - ifrac, winsize -1 - jpeak - jfrac    
 
 def fftdx(Im1, Im2, field):


### PR DESCRIPTION
In par2vel/piv2d.py, function gauss_interpolate1(x) (begins line 27), I added a statement that creates a ValueError, if any element in x<=0. This will engage the except statement and avoid the function from returning 'nan' values.